### PR TITLE
Fix HTTPs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# No trailing slash or protocol (http/s)
+HOST=website.com

--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -10,7 +10,7 @@ export function middleware(nextRequest, _fetchEvent) {
     nextRequest.headers.get("x-forwarded-proto") !== "https" ||
     nextRequest.nextUrl.hostname.startsWith(wwwSubdomain)
   ) {
-    return nextResponse.redirect(`https://${process.env.HOST || nextRequest.nextUrl.hostname.replace(wwwSubdomain, "")}/${nextRequest.nextUrl.pathname}`, 301)
+    return nextResponse.redirect(`https://${process.env.HOST || nextRequest.nextUrl.hostname.replace(wwwSubdomain, "")}${nextRequest.nextUrl.pathname}`, 301)
   }
 
   return nextResponse.next()

--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -10,7 +10,7 @@ export function middleware(nextRequest, _fetchEvent) {
     nextRequest.headers.get("x-forwarded-proto") !== "https" ||
     nextRequest.nextUrl.hostname.startsWith(wwwSubdomain)
   ) {
-    return nextResponse.redirect(`https://${nextRequest.nextUrl.hostname.replace(wwwSubdomain, "")}${nextRequest.nextUrl.pathname}`, 301)
+    return nextResponse.redirect(`https://${process.env.HOST || nextRequest.nextUrl.hostname.replace(wwwSubdomain, "")}/${nextRequest.nextUrl.pathname}`, 301)
   }
 
   return nextResponse.next()


### PR DESCRIPTION
Added support for setting `HOST`. This was defaulting to `localhost` in prod because of how heroku runs the instance